### PR TITLE
Add category button

### DIFF
--- a/Fiji.app/jars/Lib/QualiAnnotations.py
+++ b/Fiji.app/jars/Lib/QualiAnnotations.py
@@ -17,18 +17,18 @@ def getTable():
 	win2 = WindowManager.getWindow("Annotations.csv")
 	
 	if win: # different of None
-		Table = win.getResultsTable()
+		table = win.getResultsTable()
 		tableTitle = "Annotations"
 		
 	elif win2 : # different of None
-		Table = win2.getResultsTable()
+		table = win2.getResultsTable()
 		tableTitle = "Annotations.csv"
 		
 	else:
-		Table = ResultsTable()
+		table = ResultsTable()
 		tableTitle = "Annotations"
 	
-	return tableTitle, Table
+	return tableTitle, table
 
 def getRoiManager():
 	"""
@@ -277,8 +277,8 @@ class CustomDialog(GenericDialogPlus):
 		imp = IJ.getImage() # get current image
 		
 		# Get current table
-		tableTitle, Table = getTable()
-		Table.showRowNumbers(True)
+		tableTitle, table = getTable()
+		table.showRowNumbers(True)
 		
 		# Check options, use getCheckboxes(), because the checkbox plugin have other checkboxes
 		checkboxes	= self.getCheckboxes()
@@ -286,7 +286,7 @@ class CustomDialog(GenericDialogPlus):
 		# Initialize Analyzer
 		doMeasure = checkboxes[-2].getState()
 		if doMeasure:
-			analyzer = Analyzer(imp, Table)
+			analyzer = Analyzer(imp, table)
 			analyzer.setMeasurement(Measurements.LABELS, False) # dont add label to table
 		
 		# Check if existing roi manager
@@ -306,22 +306,22 @@ class CustomDialog(GenericDialogPlus):
 					analyzer.measure() # as selected in Set Measurements
 					
 				else:
-					Table.incrementCounter() # Automatically done if doMeasure 
+					table.incrementCounter() # Automatically done if doMeasure 
 				
-				#Table.addValue("Index", Table.getCounter() )  
+				#table.addValue("Index", table.getCounter() )  
 				for key, value in getImageDirAndName(imp).iteritems():
-					Table.addValue(key, value) 
+					table.addValue(key, value) 
 				
 				# Add selected items (implementation-specific)
-				self.fillTable(Table)
+				self.fillTable(table)
 		 
 				# Read comment 
 				stringField = self.getStringFields()[0] 
-				Table.addValue("Comment", stringField.text)
+				table.addValue("Comment", stringField.text)
 
 				# Add roi name to the table + set its property
-				Table.addValue("Roi", roi.getName()) # Add roi name to table
-				setRoiProperties(roi, Table)
+				table.addValue("Roi", roi.getName()) # Add roi name to table
+				setRoiProperties(roi, table)
 					
 		# No roi selected in the Manager
 		else:
@@ -330,18 +330,18 @@ class CustomDialog(GenericDialogPlus):
 				analyzer.measure() # as selected in Set Measurements
 				
 			else:
-				Table.incrementCounter() # Automatically done if doMeasure 
+				table.incrementCounter() # Automatically done if doMeasure 
 			
-			#Table.addValue("Index", Table.getCounter() )  
+			#table.addValue("Index", table.getCounter() )  
 			for key, value in getImageDirAndName(imp).iteritems():
-				Table.addValue(key, value) 
+				table.addValue(key, value) 
 
 			# Add selected items (implementation-specific)
-			self.fillTable(Table)
+			self.fillTable(table)
 	 
 			# Read comment 
 			stringField = self.getStringFields()[0] 
-			Table.addValue("Comment", stringField.text) 
+			table.addValue("Comment", stringField.text) 
 			
 			# Check if an active Roi, not yet present in Manager
 			roi = imp.getRoi()
@@ -354,11 +354,11 @@ class CustomDialog(GenericDialogPlus):
 				# get back the roi from the manager to set properties
 				roiBis	= rm.getRoi(rm.getCount()-1) 
 				roiName = roiBis.getName()
-				Table.addValue("Roi", roiName) # Add roi name to table
-				setRoiProperties(roiBis, Table)
+				table.addValue("Roi", roiName) # Add roi name to table
+				setRoiProperties(roiBis, table)
 		
-		Table.show(tableTitle) # Update table		
-		#Table.updateResults() # only for result table but then addValue does not work !  
+		table.show(tableTitle) # Update table		
+		#table.updateResults() # only for result table but then addValue does not work !  
 		  
 		# Go to next slice
 		doNext    = checkboxes[-1].getState()

--- a/Fiji.app/jars/Lib/QualiAnnotations.py
+++ b/Fiji.app/jars/Lib/QualiAnnotations.py
@@ -126,6 +126,10 @@ class CustomDialog(GenericDialogPlus):
 		self.addButton("Add new category", self) # the GUI also catches the event for this button too
 		self.addStringField("Comments", "")
 	
+	def getPanel(self):
+		"""Return the panel contained in the GenericDialog"""
+		return self.getComponent(1) # Might need to adapt it, if we add more items before the panel
+	
 	def actionPerformed(self, event):
 		'''
 		Overwrite default: to save parameters in memory when ok is clicked
@@ -169,7 +173,7 @@ class CustomDialog(GenericDialogPlus):
 		
 		# Add new component to the gui for this category and repaint GUI
 		newComponent = self.makeCategoryComponent(newCategory)
-		self.getComponent(1).add(newComponent) # component 1 is the panel
+		self.getPanel().add(newComponent) # component 1 is the panel
 		self.validate() # recompute the layout and update the display
 	
 	def addDefaultOptions(self):

--- a/Fiji.app/jars/Lib/QualiAnnotations.py
+++ b/Fiji.app/jars/Lib/QualiAnnotations.py
@@ -185,9 +185,9 @@ class CustomDialog(GenericDialogPlus):
 	def addAction(self):
 		"""
 		Action following the action clicking the button "Add" 
-		This method can be overwritten in descendant class, if more than the classical doAction
+		This method can be overwritten in descendant class, if more than the classical defaultActionSequence
 		"""
-		self.doAction()
+		self.defaultActionSequence()
 		
 	def makeCategoryComponent(self, category):
 		"""
@@ -251,7 +251,7 @@ class CustomDialog(GenericDialogPlus):
 		'''
 		Handle keyboard shortcuts (either + or F1-F12)
 		the method should be implemented in descendant classes
-		but it should usually call self.doAction()
+		but it should usually call self.defaultActionSequence()
 		'''
 		pass
 	
@@ -260,13 +260,20 @@ class CustomDialog(GenericDialogPlus):
 		listChoices = self.getChoices()
 		return listChoices[0].getSelectedItem()
 	
-	def doAction(self):
-		'''
-		Main function called if a button is clicked or shortcut called
-		It does the default stuff (adding imageName...)
-		+ it also calls the function fillTable which should be implemented in descendant classes
-		DO NOT OVERWRITE
-		'''
+	def defaultActionSequence(self):
+		"""
+		Central function (DO NOT OVERWRITE) called if a button is clicked or shortcut called
+		It trigger the following actions:
+		- getting the current table
+		- checking the GUI state (checkboxes, dropdown...)
+		- running measurements if measure is selected
+		- setting ROI attribute (if roi)
+		- incrementing table counter
+		- adding image directory and name to table
+		- filling columns from GUI state using custom fillTable()
+		- switching to next slice
+		- displaying the annotation GUI to the front, important to catch next keyboard shortcuts
+		"""
 		imp = IJ.getImage() # get current image
 		
 		# Get current table

--- a/Fiji.app/jars/Lib/QualiAnnotations.py
+++ b/Fiji.app/jars/Lib/QualiAnnotations.py
@@ -5,7 +5,7 @@ from ij.measure		  import ResultsTable, Measurements
 import os
 from collections	import OrderedDict
 from java.awt.event import ActionListener
-from java.awt 		import Label
+from java.awt 		import Label, Component
 from fiji.util.gui	import GenericDialogPlus
 
 hyperstackDim = ["time", "channel", "Z-slice"]
@@ -173,6 +173,8 @@ class CustomDialog(GenericDialogPlus):
 		
 		# Add new component to the gui for this category and repaint GUI
 		newComponent = self.makeCategoryComponent(newCategory)
+		if newComponent is None: return
+		if not isinstance(newComponent, Component): raise TypeError("Expect a component to be added to the dialog")
 		self.getPanel().add(newComponent) # component 1 is the panel
 		self.validate() # recompute the layout and update the display
 	

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
@@ -17,6 +17,10 @@ from QualiAnnotations import CustomDialog, ButtonAction
 import os 
  
 class MainDialog(CustomDialog):
+	"""
+	Main annotation dialog for this plugin
+	In this case the panel contains checkboxes
+	"""
 	
 	def __init__(self, title, message, panel):
 		CustomDialog.__init__(self, title, message, panel)

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
@@ -12,7 +12,7 @@ It will also skip to the next slice for stacks.
 from ij.gui		    import GenericDialog
 from ij 			import IJ
 from java.awt 		import GridLayout, Button, Panel, Checkbox
-from QualiAnnotations import CustomDialog, ButtonAction
+from QualiAnnotations import CustomDialog
 import os 
  
 class MainDialog(CustomDialog):
@@ -23,7 +23,7 @@ class MainDialog(CustomDialog):
 	
 	def fillTable(self, table):
 		'''Read checkbox state and update table'''  
-		for checkbox in self.getComponent(1).getComponents(): # component 1 is the panel
+		for checkbox in self.getPanel().getComponents():
 			table.addValue( checkbox.getLabel(), checkbox.getState() )
 	
 	def keyPressed(self, keyEvent):
@@ -91,11 +91,5 @@ if catDialog.wasOKed():
 	message = """Tick the categories corresponding to the current image, then click 'Add' or press the '+' key.
 	To annotate ROI, draw a new ROI or select some ROI(s) in the RoiManager before clicking 'Add'/pressing '+'."""
 	
-	
-	winButton = MainDialog(title, message, catPanel)
-	winButton.addButton("Add", ButtonAction(winButton))
-	 
-	# Add defaults 
-	winButton.addDefaultOptions() 
+	winButton = MainDialog(title, message, catPanel) 
 	winButton.showDialog()
-

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
@@ -1,6 +1,6 @@
 #@ Integer (Label = "Number of categories", value=2, min=1, stepSize=1) N_category_   
 #@ PrefService pref   
-#@ ImageJ ij   
+#@ ImageJ imagej   
 '''
 This script can be used to manually classify full images from a stack into N user-defined categories.   
 A first window pops up to request the number of categories.   
@@ -38,7 +38,7 @@ class MainDialog(CustomDialog):
 			self.doAction()
  
 ############### GUI - CATEGORY DIALOG - collect N classes names (N define at first line)  #############
-listCat = pref.getList(ij.class, "listCat_")  # try to retrieve the list of categories from the persistence, if not return [] - ij.class workaround see https://forum.image.sc/t/store-a-list-using-the-persistence-prefservice/26449   
+listCat = pref.getList(imagej.class, "listCat_")  # try to retrieve the list of categories from the persistence, if not return [] - ij.class workaround see https://forum.image.sc/t/store-a-list-using-the-persistence-prefservice/26449   
 
 # Add N string fields to the dialog for class names   
 catDialog = GenericDialog("Categories names")   
@@ -92,7 +92,7 @@ if catDialog.wasOKed():
 		catPanel.add(box)   
 	   
 	# Save categories in memory   
-	pref.put(ij.class, "listCat_", listCat )
+	pref.put(imagej.class, "listCat_", listCat )
 	
 	## Initialize dialog
 	title = "Qualitative Annotations - multi-classes (checkboxes)"

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
@@ -10,12 +10,28 @@ Clicking on the button will generate a new entry in a table with the image name 
 It will also skip to the next slice for stacks.   
 '''
 from ij.gui		    import GenericDialog   
-from java.awt 		import GridLayout, Button, Panel , Checkbox  
+from java.awt 		import GridLayout, Button, Panel, Checkbox
+from java.awt.event import ActionListener
 from collections 	import OrderedDict 
-from QualiAnnotations import AddDialog, ButtonAction
+from QualiAnnotations import CustomDialog, ButtonAction
 import os 
  
- 
+class MainDialog(CustomDialog):
+	
+	def __init__(self, title, message, panel):
+		CustomDialog.__init__(self, title, message, panel)
+		self.panel = panel # Expose the panel to the other functions
+	
+	def fillTable(self, table):
+		'''Read checkbox state and update table'''  
+		for cat, box in dicoBox.iteritems():   
+			table.addValue(cat, box.getState() ) 
+	
+	def keyPressed(self, keyEvent):
+		'''Pressing any of the + key also adds to the table like the Add button''' 
+		code = keyEvent.getKeyCode()
+		if code == keyEvent.VK_ADD or code==keyEvent.VK_PLUS: 
+			self.doAction()
  
 ############### GUI - CATEGORY DIALOG - collect N classes names (N define at first line)  #############
 listCat = pref.getList(ij.class, "listCat_")  # try to retrieve the list of categories from the persistence, if not return [] - ij.class workaround see https://forum.image.sc/t/store-a-list-using-the-persistence-prefservice/26449   
@@ -38,6 +54,20 @@ catDialog.showDialog()
  
  
 ################# After OK clicking ###########   
+class NewCategoryAction(ActionListener): # extends action listener	
+	
+	def __init__(self):
+		ActionListener.__init__(self)
+	
+	def actionPerformed(self, event):  
+		'''
+		Called when button "Add new category" is clicked
+		'''
+		# Prompt a string input
+		# Recover the new category name
+		# close the winButton and redisplay it
+		pass
+		
 # Recover fields from the formular   
 if catDialog.wasOKed():    
 	
@@ -65,10 +95,6 @@ if catDialog.wasOKed():
 	message = """Tick the categories corresponding to the current image, then click 'Add' or press the '+' key.
 	To annotate ROI, draw a new ROI or select some ROI(s) in the RoiManager before clicking 'Add'/pressing '+'."""
 	
-	def fillTable(Table): 
-		'''Read checkbox state and update table'''  
-		for cat, box in dicoBox.iteritems():   
-			Table.addValue(cat, box.getState() ) 
 	
 	winButton = AddDialog(title, message, catPanel, fillTable)
 	winButton.addButton("Add", ButtonAction(winButton))   
@@ -76,4 +102,4 @@ if catDialog.wasOKed():
 	# Add defaults 
 	winButton.addDefaultOptions() 
 	winButton.showDialog()
-  
+

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
@@ -24,8 +24,8 @@ class MainDialog(CustomDialog):
 	
 	def fillTable(self, table):
 		'''Read checkbox state and update table'''  
-		for cat, box in dicoBox.iteritems():   
-			table.addValue(cat, box.getState() ) 
+		for checkbox in self.panel.getComponents():
+			table.addValue( checkbox.getLabel(), checkbox.getState() )
 	
 	def keyPressed(self, keyEvent):
 		'''Pressing any of the + key also adds to the table like the Add button''' 
@@ -72,23 +72,23 @@ class NewCategoryAction(ActionListener): # extends action listener
 if catDialog.wasOKed():    
 	
 	# Loop over categories, adding a tickbox to the panel for each  
-	dicoBox  = OrderedDict()          # contains (categoryName: CheckBox) 
 	catPanel = Panel(GridLayout(0,4)) # Unlimited number of rows - fix to 4 columns  
+	listCat = [] # for perstistence
 	for i in range(N_category_):   
 		   
 		# Recover the category name   
 		category = catDialog.getNextString()   
+		listCat.append(category)
 
 		# Make a checkbox with the category name
 		box = Checkbox(category, False)
 		box.setFocusable(False) # important to have the keybard shortcut working
-		dicoBox[category] = box  
 
 		# Add checkbox to the gui for this category   
 		catPanel.add(box)   
 	   
 	# Save categories in memory   
-	pref.put(ij.class, "listCat_", dicoBox.keys() )   
+	pref.put(ij.class, "listCat_", listCat )
 	
 	## Initialize dialog
 	title = "Qualitative Annotations - multi-classes (checkboxes)"
@@ -96,7 +96,7 @@ if catDialog.wasOKed():
 	To annotate ROI, draw a new ROI or select some ROI(s) in the RoiManager before clicking 'Add'/pressing '+'."""
 	
 	
-	winButton = AddDialog(title, message, catPanel, fillTable)
+	winButton = MainDialog(title, message, catPanel)
 	winButton.addButton("Add", ButtonAction(winButton))   
 	 
 	# Add defaults 

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
@@ -30,7 +30,7 @@ class MainDialog(CustomDialog):
 		"""Define shortcut: pressing any of the + key also adds to the table like the Add button""" 
 		code = keyEvent.getKeyCode()
 		if code == keyEvent.VK_ADD or code==keyEvent.VK_PLUS: 
-			self.doAction()
+			self.defaultActionSequence()
 	
 	def makeCategoryComponent(self, category):
 		"""

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
@@ -32,7 +32,7 @@ class MainDialog(CustomDialog):
 			table.addValue( checkbox.getLabel(), checkbox.getState() )
 	
 	def keyPressed(self, keyEvent):
-		'''Pressing any of the + key also adds to the table like the Add button''' 
+		"""Define shortcut: pressing any of the + key also adds to the table like the Add button""" 
 		code = keyEvent.getKeyCode()
 		if code == keyEvent.VK_ADD or code==keyEvent.VK_PLUS: 
 			self.doAction()

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
@@ -9,7 +9,8 @@ Finally a third window will show up with one button per category.
 Clicking on the button will generate a new entry in a table with the image name and the category.   
 It will also skip to the next slice for stacks.   
 '''
-from ij.gui		    import GenericDialog   
+from ij.gui		    import GenericDialog
+from ij 			import IJ
 from java.awt 		import GridLayout, Button, Panel, Checkbox
 from java.awt.event import ActionListener
 from collections 	import OrderedDict 
@@ -60,17 +61,32 @@ catDialog.showDialog()
 ################# After OK clicking ###########   
 class NewCategoryAction(ActionListener): # extends action listener	
 	
-	def __init__(self):
+	def __init__(self, dialog):
 		ActionListener.__init__(self)
+		self.dialog = dialog
 	
+	def addCategory(self, category):
+		"""Add a new component to the dialog provided a new category name"""
+		
+		# Make a new checkbox with the category name
+		checkbox = Checkbox(category, False)
+		checkbox.setFocusable(False) # important to have the keybard shortcut working
+
+		# Add checkbox to the gui for this category and repaint GUI
+		panel = self.dialog.getComponent(1)
+		panel.add(checkbox)
+		self.dialog.validate() # recompute the layout and update the display
+		
 	def actionPerformed(self, event):  
-		'''
+		"""
 		Called when button "Add new category" is clicked
-		'''
-		# Prompt a string input
-		# Recover the new category name
-		# close the winButton and redisplay it
-		pass
+		This method could be defined in the mother class 
+		"""
+		newCategory = IJ.getString("Enter new category name", "new category")
+		if not newCategory: return # if Cancelled (ie newCat=="") or empty field just dont go further 
+		self.addCategory(newCategory)
+		
+		
 		
 # Recover fields from the formular   
 if catDialog.wasOKed():    
@@ -101,7 +117,9 @@ if catDialog.wasOKed():
 	
 	
 	winButton = MainDialog(title, message, catPanel)
-	winButton.addButton("Add", ButtonAction(winButton))   
+	winButton.addButton("Add", ButtonAction(winButton))
+	winButton.addButton("Add new category", NewCategoryAction(winButton)) 
+
 	 
 	# Add defaults 
 	winButton.addDefaultOptions() 

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
@@ -21,7 +21,7 @@ import os
 listCat = pref.getList(ij.class, "listCat_")  # try to retrieve the list of categories from the persistence, if not return [] - ij.class workaround see https://forum.image.sc/t/store-a-list-using-the-persistence-prefservice/26449   
 
 # Add N string fields to the dialog for class names   
-Win = GenericDialog("Categories names")   
+catDialog = GenericDialog("Categories names")   
 
 for i in range(N_category_):
 	
@@ -31,15 +31,15 @@ for i in range(N_category_):
 	else:  
 		catName = "Category_" + str(i+1)   
 	  
-	Win.addStringField("Category: ", catName)   
-	Win.addMessage("") # skip one line   
+	catDialog.addStringField("Category: ", catName)   
+	catDialog.addMessage("") # skip one line   
 	   
-Win.showDialog()   
+catDialog.showDialog()   
  
  
 ################# After OK clicking ###########   
 # Recover fields from the formular   
-if Win.wasOKed():    
+if catDialog.wasOKed():    
 	
 	# Loop over categories, adding a tickbox to the panel for each  
 	dicoBox  = OrderedDict()          # contains (categoryName: CheckBox) 
@@ -47,7 +47,7 @@ if Win.wasOKed():
 	for i in range(N_category_):   
 		   
 		# Recover the category name   
-		category = Win.getNextString()   
+		category = catDialog.getNextString()   
 
 		# Make a checkbox with the category name
 		box = Checkbox(category, False)

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
@@ -17,15 +17,17 @@ import os
  
  
  
-############### GUI - CATEGORY DIALOG - collect N classes names (N define at first line)  #############   
+############### GUI - CATEGORY DIALOG - collect N classes names (N define at first line)  #############
+listCat = pref.getList(ij.class, "listCat_")  # try to retrieve the list of categories from the persistence, if not return [] - ij.class workaround see https://forum.image.sc/t/store-a-list-using-the-persistence-prefservice/26449   
+
+# Add N string fields to the dialog for class names   
 Win = GenericDialog("Categories names")   
-   
-# Add N string fields for class names   
-for i in range(N_category_):   
-	listCat = pref.getList(ij.class, "listCat_")            # try to retrieve the list of categories from the persistence, if not return [] - ij.class workaround see https://forum.image.sc/t/store-a-list-using-the-persistence-prefservice/26449   
-	  
-	if listCat and i<=len(listCat)-1:  
+
+for i in range(N_category_):
+	
+	if listCat and i<=len(listCat)-1:  # read previous categories
 		catName = listCat[i]  
+	
 	else:  
 		catName = "Category_" + str(i+1)   
 	  

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(dropdown).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(dropdown).py
@@ -11,7 +11,8 @@ Broken, ,
 '''
 #@ File (label="CSV file for category and choice", style="extension:csv") csvpath
 from java.awt 		import Panel, Choice, Label, GridLayout
-from QualiAnnotations import CustomDialog, ButtonAction
+from fiji.util.gui	import GenericDialogPlus
+from QualiAnnotations import CustomDialog
 import os, csv, codecs
 
 class MainDialog(CustomDialog):
@@ -19,6 +20,18 @@ class MainDialog(CustomDialog):
 	Main annotation dialog for this plugin
 	In this case the panel contains dropdowns
 	"""
+
+	def __init__(self, title, message, panel):
+		"""Custom constructor instead of the CustomDialog constructor: does not add the "Add" button"""
+		GenericDialogPlus.__init__(self, title)
+		self.setModalityType(None) # like non-blocking generic dialog
+		self.addMessage(message)
+		self.addPanel(panel)
+		#self.addButton("Add new category", self) # no add new category button for dropdown
+		self.addStringField("Comments", "")
+		self.addButton("Add", self)
+		self.addDefaultOptions()
+	
 	def fillTable(self, table):
 		'''Read dropdown states and update table'''  
 		for dropdown in ( self.getPanel().getComponents()[n:] ): # n first elements are the labels
@@ -32,10 +45,8 @@ class MainDialog(CustomDialog):
 	
 	def makeCategoryComponent(self, category):
 		"""
-		Generates a checkbox with the new category name, to add to the GUI
-		Overwrite the original method
+		Could return a new dropdown, but not implemented
 		"""
-		# TO DO
 		return None
 
 
@@ -99,10 +110,4 @@ message = """Select the descriptors corresponding to the current image, then cli
 To annotate ROI, draw a new ROI or select some ROI(s) from the RoiManager before clicking 'Add'/pressing '+'."""
 
 win = MainDialog(title, message, panel)
-
-# Add button to window 
-win.addButton("Add", ButtonAction(win))
-
-# Add defaults
-win.addDefaultOptions()
 win.showDialog()

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(dropdown).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(dropdown).py
@@ -11,8 +11,33 @@ Broken, ,
 '''
 #@ File (label="CSV file for category and choice", style="extension:csv") csvpath
 from java.awt 		import Panel, Choice, Label, GridLayout
-from QualiAnnotations import AddDialog, ButtonAction
+from QualiAnnotations import CustomDialog, ButtonAction
 import os, csv, codecs
+
+class MainDialog(CustomDialog):
+	"""
+	Main annotation dialog for this plugin
+	In this case the panel contains dropdowns
+	"""
+	def fillTable(self, table):
+		'''Read dropdown states and update table'''  
+		for dropdown in ( self.getPanel().getComponents()[n:] ): # n first elements are the labels
+			table.addValue( dropdown.getName(), dropdown.getSelectedItem() )
+	
+	def keyPressed(self, keyEvent):
+		"""Define shortcut: pressing any of the + key also adds to the table like the Add button""" 
+		code = keyEvent.getKeyCode()
+		if code == keyEvent.VK_ADD or code==keyEvent.VK_PLUS: 
+			self.doAction()
+	
+	def makeCategoryComponent(self, category):
+		"""
+		Generates a checkbox with the new category name, to add to the GUI
+		Overwrite the original method
+		"""
+		# TO DO
+		return None
+
 
 ### Read CSV to get categories and choices
 csvPath = csvpath.getPath()
@@ -68,19 +93,12 @@ for i in range(n):
 	panel.add(chooser)
 
 
-# Define custom action on button click (in addition to default)
-def fillTable(Table):
-	'''Called when Add is clicked'''
-	for dropdown in ( panel.getComponents()[n:] ): # n first elements are the labels
-		Table.addValue(dropdown.getName(), dropdown.getSelectedItem() )
-
-
 # Initialize classification GUI
 title   = "Qualitative Annotations - multi-classes (dropdown)"
 message = """Select the descriptors corresponding to the current image, then click 'Add' or press one of the '+' key.
 To annotate ROI, draw a new ROI or select some ROI(s) from the RoiManager before clicking 'Add'/pressing '+'."""
 
-win = AddDialog(title, message, panel, fillTable)
+win = MainDialog(title, message, panel)
 
 # Add button to window 
 win.addButton("Add", ButtonAction(win))

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(dropdown).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(dropdown).py
@@ -41,7 +41,7 @@ class MainDialog(CustomDialog):
 		"""Define shortcut: pressing any of the + key also adds to the table like the Add button""" 
 		code = keyEvent.getKeyCode()
 		if code == keyEvent.VK_ADD or code==keyEvent.VK_PLUS: 
-			self.doAction()
+			self.defaultActionSequence()
 	
 	def makeCategoryComponent(self, category):
 		"""

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/single_class_(button).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/single_class_(button).py
@@ -19,9 +19,9 @@ class ButtonAction(ActionListener):
 	'''Define what happens when a category button is clicked'''
 	
 	def actionPerformed(self, event): 
-		'''Update the selected category and doAction to fill the table'''
+		'''Update the selected category and defaultActionSequence to fill the table'''
 		winButton.selectedCategory = event.getSource().getLabel() 
-		winButton.doAction() 
+		winButton.defaultActionSequence() 
 		 
 # Define global actionListener for buttons: they share the same one, associated to the dialog
 buttonAction = ButtonAction()
@@ -29,7 +29,7 @@ buttonAction = ButtonAction()
 class ButtonDialog(CustomDialog): 
 	'''
 	Annotation dialog, also define keyboard shortcut and function to fill the table
-	doAction() is defined in the mother class customDialog
+	defaultActionSequence() is defined in the mother class customDialog
 	'''
 	
 	def __init__(self, title, message, panel, choiceIndex): 
@@ -58,7 +58,7 @@ class ButtonDialog(CustomDialog):
 		if code in listShortcut: 
 			index = listShortcut.index(code)
 			self.selectedCategory = listCat[index] 
-			self.doAction() 	 
+			self.defaultActionSequence() 	 
 
 	def makeCategoryComponent(self, category):
 		"""Return a button with the new category name, and mapped to the action"""

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/single_class_(button).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/single_class_(button).py
@@ -52,7 +52,7 @@ class ButtonDialog(CustomDialog):
 		'''
 		Map button to keyboard shortcuts (use F1..F12)
 		ie one can press F1 to assign to the first category instead of clicking the button
-		'''		 
+		'''
 		code = keyEvent.getKeyCode()
 		
 		if code in listShortcut: 
@@ -139,5 +139,4 @@ if (Win.wasOKed()):
 	winButton = ButtonDialog(title, message, catPanel, choiceIndex)
 	
 	# Add default fields 
-	winButton.addDefaultOptions() 
 	winButton.showDialog()

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/single_class_(button).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/single_class_(button).py
@@ -12,24 +12,26 @@ It will also skip to the next slice for stacks.
 from ij.gui		    import GenericDialog
 from java.awt 		import GridLayout, Button, Panel 
 from java.awt.event import ActionListener
-from QualiAnnotations import CustomDialog, getTable, ButtonAction
+from QualiAnnotations import CustomDialog, getTable
 import os  
 
 class ButtonAction(ActionListener): 
-	'''Define what happens when a button is clicked'''
+	'''Define what happens when a category button is clicked'''
 	
 	def actionPerformed(self, event): 
 		'''Update the selected category and doAction to fill the table'''
 		winButton.selectedCategory = event.getSource().getLabel() 
 		winButton.doAction() 
 		 
- 
+# Define global actionListener for buttons: they share the same one, associated to the dialog
+buttonAction = ButtonAction()
+
 class ButtonDialog(CustomDialog): 
 	'''
 	Annotation dialog, also define keyboard shortcut and function to fill the table
 	doAction() is defined in the mother class customDialog
 	'''
-		
+	
 	def __init__(self, title, message, panel, choiceIndex): 
 		CustomDialog.__init__(self, title, message, panel) 
 		self.choiceIndex = choiceIndex 
@@ -58,7 +60,14 @@ class ButtonDialog(CustomDialog):
 			self.selectedCategory = listCat[index] 
 			self.doAction() 	 
 
+	def makeCategoryComponent(self, category):
+		"""Return a button with the new category name, and mapped to the action"""
+		listCat.append(category)
 		
+		button = Button(category)
+		button.addActionListener(buttonAction)
+		button.setFocusable(False)
+		return button
   
 ############### GUI - CATEGORY DIALOG - collect N classes names (N define at first line)  #############  
   
@@ -71,8 +80,9 @@ Win.addChoice("Classification table shoud have",
 				choice[indexDefault] ) 
   
 # Add N string field to get class names 
+listCat = pref.getList(ij.class, "listCat")            # try to retrieve the list of categories from the persistence, if not return [] - ij.class workaround see https://forum.image.sc/t/store-a-list-using-the-persistence-prefservice/26449 
+
 for i in range(N_category): 
-	listCat = pref.getList(ij.class, "listCat")            # try to retrieve the list of categories from the persistence, if not return [] - ij.class workaround see https://forum.image.sc/t/store-a-list-using-the-persistence-prefservice/26449 
 	 
 	if listCat and i<=len(listCat)-1: 
 		catName = listCat[i] 
@@ -100,9 +110,6 @@ if (Win.wasOKed()):
 	# Loop over categories and add a button to the panel for each  
 	catPanel = Panel(GridLayout(0,4)) # Unlimited number of rows - fix to 4 columns 
 	
-	# Define actionListener for buttons: they share the same one, associated to the dialog
-	action = ButtonAction()
-	
 	listCat = []
 	listShortcut = range(112, 112+N_category)
 	
@@ -116,7 +123,7 @@ if (Win.wasOKed()):
 		button = Button(Cat) # button label 
 		
 		# Bind action to button  
-		button.addActionListener(action)  
+		button.addActionListener(buttonAction)  
 		
 		# Add a button to the gui for this category  
 		button.setFocusable(False) # prevent the button to take the focus, only the window should be able to take the keyboard shortcut


### PR DESCRIPTION
This PR adds several changes, especially the CustomDialog class is extended and contains most functionality.
All plugins are now derived from it.
For the single category and checkbox, new items can be defined using the "Add new category" button as proposed in #12.

To do: - keyboard shortcut associated to the new button 
