### PR TITLE
Add previous/next button

### DIFF
--- a/Fiji.app/jars/Lib/QualiAnnotations.py
+++ b/Fiji.app/jars/Lib/QualiAnnotations.py
@@ -1,4 +1,5 @@
-from ij				  import IJ, WindowManager, Prefs
+from ij				import IJ, WindowManager, Prefs
+from ij.gui			import GenericDialog
 from ij.plugin.filter import Analyzer
 from ij.plugin.frame  import RoiManager
 from ij.measure		  import ResultsTable, Measurements
@@ -110,7 +111,46 @@ def setRoiProperties(roi, table):
 		value = table.getStringValue(heading, table.size()-1)
 		roi.setProperty(heading, value)
 
-
+class CategoryDialog(GenericDialog):
+	"""Dialog prompting the category names, used by the single class button and checkbox plugins"""
+	
+	def __init__(self, nCategories):
+		
+		GenericDialog.__init__(self, "Category names")
+		self.nCategories = nCategories
+		
+		# Get previous categories from persistence
+		stringCat = Prefs.get("annot.listCat", "") # Retrieve the list of categories as a comma separated list
+		self.listCategories = stringCat.split(",") if stringCat else []
+		nOldCat = len(self.listCategories) 
+		
+		for i in range(nCategories): 
+	 
+			if self.listCategories and i<=nOldCat-1:	catName = self.listCategories[i] 
+			else:										catName = "Category_" + str(i+1) 
+			
+			# Add string input to GUI
+			self.addStringField("Category: ", catName) 
+			self.addMessage("") # skip one line before the next input field
+	
+	
+	def actionPerformed(self, event):
+		"""Save categories names in memory if OKed"""
+		
+		sourceLabel = event.getSource().getLabel()
+		
+		if sourceLabel == "  OK  ": 
+			self.listCategories = [textField.getText() for textField in self.getStringFields()]
+			Prefs.set("annot.listCat", ",".join(self.listCategories) ) # save the new list of categories
+		
+		# Do the mother class usual action handling()
+		GenericDialogPlus.actionPerformed(self, event)
+		
+	
+	def getCategoryNames(self):
+		return self.listCategories
+		
+		
 class CustomDialog(GenericDialogPlus):
 	'''
 	Model class for the plugin dialog for the manual classifier

--- a/Fiji.app/jars/Lib/QualiAnnotations.py
+++ b/Fiji.app/jars/Lib/QualiAnnotations.py
@@ -1,5 +1,6 @@
 from ij				import IJ, WindowManager, Prefs
 from ij.gui			import GenericDialog
+from ij.plugin		import NextImageOpener
 from ij.plugin.filter import Analyzer
 from ij.plugin.frame  import RoiManager
 from ij.measure		  import ResultsTable, Measurements
@@ -149,8 +150,25 @@ class CategoryDialog(GenericDialog):
 	
 	def getCategoryNames(self):
 		return self.listCategories
+
+
+class BrowseButton(ActionListener):
+	"""Implement the action following click on Previous/Next image"""
+	
+	labelPrevious = "Previous image file"
+	labelNext     = "Next image file"
+	imageOpener   =  NextImageOpener()
+
+	def actionPerformed(self, event):
+		label = event.getSource().getLabel()
 		
+		if label == self.labelPrevious:
+			self.imageOpener.run("backward")
 		
+		elif label == self.labelNext:
+			self.imageOpener.run("forward")
+
+
 class CustomDialog(GenericDialogPlus):
 	'''
 	Model class for the plugin dialog for the manual classifier
@@ -175,8 +193,11 @@ class CustomDialog(GenericDialogPlus):
 	- fillTable(table), function stating how to add to the table
 	'''
 	
-	def __init__(self, title, message, panel):
-		"""This can be overwritten to readjust the order or if some component are not needed"""
+	def __init__(self, title, message, panel, browseMode="stack"):
+		"""
+		This can be overwritten to readjust the order or if some components are not needed
+		The browseMode is either "stack" or "directory"
+		"""
 		GenericDialogPlus.__init__(self, title)
 		self.setModalityType(None) # like non-blocking generic dialog
 		self.addMessage(message)
@@ -184,8 +205,11 @@ class CustomDialog(GenericDialogPlus):
 		self.addButton("Add new category", self) # the GUI also catches the event for this button too
 		self.addStringField("Comments", "")
 		self.addButton("Add", self)
+		
+		self.browseMode = browseMode # important to define it before addDefaultOptions and nextSlice...
 		self.addDefaultOptions()
 		self.addCitation()
+		
 	
 	def getPanel(self):
 		"""Return the panel contained in the GenericDialog"""
@@ -255,20 +279,29 @@ class CustomDialog(GenericDialogPlus):
 	def addDefaultOptions(self):
 		'''
 		Add default GUI items
+		- checkbox runMeasurement
 		- add to Manager, nextSlice, runMeasurement
 		- resource message
 		- help button
 		'''
 		# Checkbox next slice and run Measure 
 		self.addCheckbox("run 'Measure'", bool(Prefs.get("annot.doMeasure", False)) )
-		self.addCheckbox("Auto next slice", bool(Prefs.get("annot.doNext", True)) )
-		self.addToSameRow()
-		self.addChoice("dimension (for hyperstack)", hyperstackDim, hyperstackDim[0])
+		self.addCheckbox("Auto next slice/image file", bool(Prefs.get("annot.doNext", True)) )
+
+		if self.browseMode == "stack":
+			self.addToSameRow()
+			self.addChoice("dimension (for hyperstack)", hyperstackDim, hyperstackDim[0])
+		
+		elif self.browseMode == "directory":
+			# Add button previous/next
+			self.addButton(BrowseButton.labelPrevious, BrowseButton())
+			self.addToSameRow()
+			self.addButton(BrowseButton.labelNext, BrowseButton())
+			
 		self.addMessage("Documentation and generic analysis workflows available on the GitHub repo (click Help)")
 		
 		# Add Help button pointing to the github
 		self.addHelp(r"https://github.com/LauLauThom/Fiji-QualiAnnotations")
-		
 		self.hideCancelButton()
 	
 	def addCitation(self):
@@ -403,7 +436,9 @@ class CustomDialog(GenericDialogPlus):
 		  
 		# Go to next slice
 		doNext    = checkboxes[-1].getState()
-		if doNext: nextSlice(imp, self.getChosenDimension() )
+		if doNext:
+			if   self.browseMode == "stack":     nextSlice(imp, self.getChosenDimension() )
+			elif self.browseMode == "directory": NextImageOpener().run("forward")
 		  
 		# Bring back the focus to the button window (otherwise the table is in the front)  
 		if not IJ.getFullVersion().startswith("1.52p"): WindowManager.toFront(self)	 # prevent some ImageJ bug with 1.52p

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
@@ -1,4 +1,5 @@
 #@ Integer (Label = "Number of categories", value=2, min=1, stepSize=1) N_category_   
+#@ String  (label = "Browsing mode", choices={"stack", "directory"}) browse_mode
 '''
 This script can be used to manually classify full images from a stack into N user-defined categories.   
 A first window pops up to request the number of categories.   
@@ -69,5 +70,5 @@ if catDialog.wasOKed():
 	message = """Tick the categories corresponding to the current image, then click 'Add' or press the '+' key.
 	To annotate ROI, draw a new ROI or select some ROI(s) in the RoiManager before clicking 'Add'/pressing '+'."""
 	
-	winButton = MainDialog(title, message, catPanel) 
+	winButton = MainDialog(title, message, catPanel, browse_mode) 
 	winButton.showDialog()

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
@@ -1,5 +1,3 @@
-#@ Integer (Label = "Number of categories", value=2, min=1, stepSize=1) N_category_   
-#@ String  (label = "Browsing mode", choices={"stack", "directory"}) browse_mode
 '''
 This script can be used to manually classify full images from a stack into N user-defined categories.   
 A first window pops up to request the number of categories.   
@@ -8,6 +6,9 @@ Finally a third window will show up with one button per category.
 Clicking on the button will generate a new entry in a table with the image name and the category.   
 It will also skip to the next slice for stacks.   
 '''
+#@ Integer (Label = "Number of categories", value=2, min=1, stepSize=1) N_category_   
+#@ String  (label = "Browsing mode", choices={"stack", "directory"}) browse_mode
+
 from ij.gui		    import GenericDialog
 from ij 			import IJ
 from java.awt 		import GridLayout, Button, Panel, Checkbox

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(checkboxes).py
@@ -1,6 +1,4 @@
 #@ Integer (Label = "Number of categories", value=2, min=1, stepSize=1) N_category_   
-#@ PrefService pref   
-#@ ImageJ imagej   
 '''
 This script can be used to manually classify full images from a stack into N user-defined categories.   
 A first window pops up to request the number of categories.   
@@ -12,7 +10,7 @@ It will also skip to the next slice for stacks.
 from ij.gui		    import GenericDialog
 from ij 			import IJ
 from java.awt 		import GridLayout, Button, Panel, Checkbox
-from QualiAnnotations import CustomDialog
+from QualiAnnotations import CustomDialog, CategoryDialog
 import os 
  
 class MainDialog(CustomDialog):
@@ -43,23 +41,10 @@ class MainDialog(CustomDialog):
 		return checkbox
  
 ############### GUI - CATEGORY DIALOG - collect N classes names (N define at first line)  #############
-listCat = pref.getList(imagej.class, "listCat_")  # try to retrieve the list of categories from the persistence, if not return [] - ij.class workaround see https://forum.image.sc/t/store-a-list-using-the-persistence-prefservice/26449   
 
-# Add N string fields to the dialog for class names   
-catDialog = GenericDialog("Categories names")   
-
-for i in range(N_category_):
-	
-	if listCat and i<=len(listCat)-1:  # read previous categories
-		catName = listCat[i]  
-	
-	else:  
-		catName = "Category_" + str(i+1)   
-	  
-	catDialog.addStringField("Category: ", catName)   
-	catDialog.addMessage("") # skip one line   
-	   
-catDialog.showDialog()   
+# Initialize a category dialog with N categories
+catDialog = CategoryDialog(N_category_)   
+catDialog.showDialog()
  
  
 ################# After OK clicking ###########   
@@ -69,22 +54,15 @@ if catDialog.wasOKed():
 	
 	# Loop over categories, adding a tickbox to the panel for each  
 	catPanel = Panel(GridLayout(0,4)) # Unlimited number of rows - fix to 4 columns  
-	listCat = [] # for perstistence
-	for i in range(N_category_):   
-		   
-		# Recover the category name   
-		category = catDialog.getNextString()   
-		listCat.append(category)
-
+	
+	for category in catDialog.getCategoryNames():   
+		
 		# Make a checkbox with the category name
 		box = Checkbox(category, False)
 		box.setFocusable(False) # important to have the keybard shortcut working
 
 		# Add checkbox to the gui for this category   
 		catPanel.add(box)   
-	   
-	# Save categories in memory   
-	pref.put(imagej.class, "listCat_", listCat )
 	
 	## Initialize dialog
 	title = "Qualitative Annotations - multi-classes (checkboxes)"

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(dropdown).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(dropdown).py
@@ -10,7 +10,7 @@ Bent, Slim
 Broken, , 
 '''
 #@ File   (label="CSV file for category and choice", style="extension:csv") csvpath
-#@ String (label="Browse mode", choices={"stack", "directory"}) browse_mode
+#@ String (label="Browsing mode", choices={"stack", "directory"}) browse_mode
 from java.awt 		import Panel, Choice, Label, GridLayout
 from fiji.util.gui	import GenericDialogPlus
 from QualiAnnotations import CustomDialog

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(dropdown).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/multi-class_(dropdown).py
@@ -9,7 +9,8 @@ Straight, Gross
 Bent, Slim
 Broken, , 
 '''
-#@ File (label="CSV file for category and choice", style="extension:csv") csvpath
+#@ File   (label="CSV file for category and choice", style="extension:csv") csvpath
+#@ String (label="Browse mode", choices={"stack", "directory"}) browse_mode
 from java.awt 		import Panel, Choice, Label, GridLayout
 from fiji.util.gui	import GenericDialogPlus
 from QualiAnnotations import CustomDialog
@@ -21,7 +22,7 @@ class MainDialog(CustomDialog):
 	In this case the panel contains dropdowns
 	"""
 
-	def __init__(self, title, message, panel):
+	def __init__(self, title, message, panel, browseMode):
 		"""Custom constructor instead of the CustomDialog constructor: does not have the "Add" button"""
 		GenericDialogPlus.__init__(self, title)
 		self.setModalityType(None) # like non-blocking generic dialog
@@ -30,8 +31,11 @@ class MainDialog(CustomDialog):
 		#self.addButton("Add new category", self) # no add new category button for dropdown
 		self.addStringField("Comments", "")
 		self.addButton("Add", self)
+		
+		self.browseMode = browseMode # important to define it before addDefaultOptions
 		self.addDefaultOptions()
 		self.addCitation()
+		
 		
 	def fillTable(self, table):
 		'''Read dropdown states and update table'''  
@@ -110,5 +114,5 @@ title   = "Qualitative Annotations - multi-classes (dropdown)"
 message = """Select the descriptors corresponding to the current image, then click 'Add' or press one of the '+' key.
 To annotate ROI, draw a new ROI or select some ROI(s) from the RoiManager before clicking 'Add'/pressing '+'."""
 
-win = MainDialog(title, message, panel)
+win = MainDialog(title, message, panel, browse_mode)
 win.showDialog()

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/single_class_(button).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/single_class_(button).py
@@ -1,6 +1,6 @@
 #@ Integer (Label = "Number of categories", value=2, min=1, stepSize=1) N_category  
-#@ PrefService pref 
-#@ ImageJ ij 
+#@ String (Label="Table structure", choices={"single category column","one column per category"}) table_structure
+#@ String (Label="Mode", choices={"Stack", "Directory"}) mode
 '''
 This script can be used to manually classify full images from a stack into N user-defined categories.  
 A first window pops up to request the number of categories.  
@@ -10,12 +10,12 @@ Clicking on the button will generate a new entry in a table with the image name 
 It will also skip to the next slice for stacks.  
 '''
 from ij.gui			import GenericDialog
-from ij 			import IJ, WindowManager
+from ij 			import IJ, WindowManager, Prefs
 from fiji.util.gui  import GenericDialogPlus
 from java.awt 		import GridLayout, Button, Panel 
 from java.awt.event import ActionListener
 from javax.swing import JButton
-from QualiAnnotations import CustomDialog, getTable
+from QualiAnnotations import CustomDialog, CategoryDialog, getTable
 from PieChart 		  import PieChart
 import os  
 
@@ -64,7 +64,7 @@ class ButtonDialog(CustomDialog):
 	defaultActionSequence() is defined in the mother class customDialog
 	'''
 	
-	def __init__(self, title, message, panel, choiceIndex): 
+	def __init__(self, title, message, panel, tableStructure): 
 		GenericDialogPlus.__init__(self, title)
 		self.setModalityType(None) # like non-blocking generic dialog
 		self.addMessage(message)
@@ -77,11 +77,11 @@ class ButtonDialog(CustomDialog):
 		self.addCitation()
 
 		# Variable used by instance methods
-		self.choiceIndex = choiceIndex 
+		self.tableStructure = tableStructure 
 		self.selectedCategory = "" 
 	 
 	def fillTable(self, table): 
-		if self.choiceIndex==0: # single category column 
+		if self.tableStructure=="single category column": # single category column 
 			table.addValue("Category", self.selectedCategory) 
 		 
 		else: # 1 column/category with 0/1 
@@ -111,6 +111,9 @@ class ButtonDialog(CustomDialog):
 		"""Return a button with the new category name, and mapped to the action"""
 		listCat.append(category)
 		
+		# Save the new category in memory
+		Prefs.set("annot.listCat", ",".join(listCat) )
+		
 		button = JButton(category)
 		button.addActionListener(buttonAction)
 		button.setFocusable(False)
@@ -122,58 +125,28 @@ class ButtonDialog(CustomDialog):
 		return button
   
 ############### GUI - CATEGORY DIALOG - collect N classes names (N define at first line)  #############  
-  
-Win = GenericDialog("Categories names") 
- 
-choice = ["a single category column", "1 column per category"] 
-indexDefault = pref.getInt("table_style", 0) 
-Win.addChoice("Classification table shoud have",  
-				choice,  
-				choice[indexDefault] ) 
-  
-# Add N string field to get class names 
-listCat = pref.getList(ij.class, "listCat")            # try to retrieve the list of categories from the persistence, if not return [] - ij.class workaround see https://forum.image.sc/t/store-a-list-using-the-persistence-prefservice/26449 
+catDialog = CategoryDialog(N_category)
+catDialog.showDialog()
 
-for i in range(N_category): 
-	 
-	if listCat and i<=len(listCat)-1: 
-		catName = listCat[i] 
-	else: 
-		catName = "Category_" + str(i+1) 
-	 
-	Win.addStringField("Category: ", catName) 
-	 
-	Win.addMessage("") # skip one line  
-	  
-Win.showDialog() 
-  
-  
+
 ################# After OK clicking ###########  
   
 # Recover fields from the formular  
-if (Win.wasOKed()):   
- 
-	# get Choice single/multi column 
-	choiceIndex = Win.getNextChoiceIndex() 
-	pref.put("table_style", choiceIndex) 
-	 
+if catDialog.wasOKed():   
+
 	tableTitle, Table = getTable()
 	
 	# Loop over categories and add a button to the panel for each  
 	catPanel = Panel(GridLayout(0,4)) # Unlimited number of rows - fix to 4 columns - not possible to use a JPanel, not supported by GenericDialog
 	
-	listCat = []
+	listCat = catDialog.getCategoryNames()
 	listShortcut = range(112, 112+N_category)
 	
-	for i in range(N_category):  
+	for index, category in enumerate(listCat): 
 		  
-		# Recover the category name  
-		Cat = Win.getNextString()  
-		listCat.append(Cat)  
-		
 		# Create a Button  
-		button = JButton(Cat) # button label 
-		if i<12: button.setToolTipText( "Keyboard shortcut: F" + str(i+1) )
+		button = JButton(category) # button label 
+		if index<12: button.setToolTipText( "Keyboard shortcut: F" + str(index+1) ) # index is 0-based, F shortcut are 1-based
 		
 		# Bind action to button  
 		button.addActionListener(buttonAction)  
@@ -181,15 +154,10 @@ if (Win.wasOKed()):
 		# Add a button to the gui for this category  
 		button.setFocusable(False) # prevent the button to take the focus, only the window should be able to take the keyboard shortcut
 		catPanel.add(button)
-		
-		
-	# Save categories in memory 
-	pref.put(ij.class, "listCat", listCat) 
 	
-	## Initialize classification gui
+	
+	# Initialize classification gui
 	title = "Qualitative Annotations - single class (buttons)"
 	message = "Click the category of the current image or ROI, or use the F1-F12 keyboard shortcuts.\nTo annotate ROI, draw a new ROI or select some ROI in the RoiManager before clicking the category button." 
-	winButton = ButtonDialog(title, message, catPanel, choiceIndex)
-	
-	# Add default fields 
+	winButton = ButtonDialog(title, message, catPanel, table_structure)
 	winButton.showDialog()

--- a/Fiji.app/scripts/Plugins/Qualitative Annotations/single_class_(button).py
+++ b/Fiji.app/scripts/Plugins/Qualitative Annotations/single_class_(button).py
@@ -1,6 +1,3 @@
-#@ Integer (Label = "Number of categories", value=2, min=1, stepSize=1) N_category  
-#@ String (Label="Table structure", choices={"single category column","one column per category"}) table_structure
-#@ String (Label="Mode", choices={"Stack", "Directory"}) mode
 '''
 This script can be used to manually classify full images from a stack into N user-defined categories.  
 A first window pops up to request the number of categories.  
@@ -9,6 +6,10 @@ Finally a third window will show up with one button per category.
 Clicking on the button will generate a new entry in a table with the image name and the category.  
 It will also skip to the next slice for stacks.  
 '''
+#@ Integer (Label = "Number of categories", value=2, min=1, stepSize=1) N_category  
+#@ String (Label="Table structure", choices={"single category column","one column per category"}) table_structure
+#@ String (Label="Browsing mode", choices={"stack", "directory"}) browse_mode
+
 from ij.gui			import GenericDialog
 from ij 			import IJ, WindowManager, Prefs
 from fiji.util.gui  import GenericDialogPlus
@@ -64,7 +65,11 @@ class ButtonDialog(CustomDialog):
 	defaultActionSequence() is defined in the mother class customDialog
 	'''
 	
-	def __init__(self, title, message, panel, tableStructure): 
+	def __init__(self, title, message, panel, browseMode="stack", tableStructure="single category column"): 
+		"""
+		browseMode: "stack" or "directory"
+		tableStructure: "single category column" or anything else, such as "one column per category"
+		"""
 		GenericDialogPlus.__init__(self, title)
 		self.setModalityType(None) # like non-blocking generic dialog
 		self.addMessage(message)
@@ -72,6 +77,7 @@ class ButtonDialog(CustomDialog):
 		self.addButton("Add new category", self) 
 		self.addStringField("Comments", "")
 		#self.addButton("Add", self) # no add button for button-plugin
+		self.browseMode = browseMode # important to define it before adding defaultOptions
 		self.addDefaultOptions()
 		#if choiceIndex == 0: self.addButton("Make PieChart from category column", PlotAction()) # Remov this button: risk of cherry picking to improve the plot
 		self.addCitation()
@@ -159,5 +165,5 @@ if catDialog.wasOKed():
 	# Initialize classification gui
 	title = "Qualitative Annotations - single class (buttons)"
 	message = "Click the category of the current image or ROI, or use the F1-F12 keyboard shortcuts.\nTo annotate ROI, draw a new ROI or select some ROI in the RoiManager before clicking the category button." 
-	winButton = ButtonDialog(title, message, catPanel, table_structure)
+	winButton = ButtonDialog(title, message, catPanel, browse_mode, table_structure)
 	winButton.showDialog()


### PR DESCRIPTION
- Introduce the central `CategoryDialog` class used by both the single class button and checkbox plugins to define the category names
- Both plugins thus share the same persistence of the category names

- Add a browseMode attribute to the `CustomDialog` class which can be `stack` or `directory`
In directory mode, with `auto-next slice/image file` the action of clicking add or a category button will open the next image.
The gui also has buttons for previous/next image.
This resolves #16 